### PR TITLE
Fix bug when .query() fails if first returned element is blank string

### DIFF
--- a/lib/src/handlers/handler.dart
+++ b/lib/src/handlers/handler.dart
@@ -56,8 +56,8 @@ abstract class _Handler {
    * a [MySqlException] if it was an Error packet, or returns [:null:] 
    * if the packet has not been handled by this method.
    */
-  dynamic checkResponse(Buffer response, [bool prepareStmt=false]) {
-    if (response[0] == PACKET_OK) {
+  dynamic checkResponse(Buffer response, [bool prepareStmt=false, bool isHandlingRows=false]) {
+    if (response[0] == PACKET_OK && !isHandlingRows) {
       if (prepareStmt) {
         var okPacket = new _PrepareOkPacket(response);
         log.fine(okPacket.toString());

--- a/lib/src/query/query_stream_handler.dart
+++ b/lib/src/query/query_stream_handler.dart
@@ -29,7 +29,7 @@ class _QueryStreamHandler extends _Handler {
 
   _HandlerResponse processResponse(Buffer response) {
     log.fine("Processing query response");
-    var packet = checkResponse(response);
+    var packet = checkResponse(response, false, _state == STATE_ROW_PACKETS);
     if (packet == null) {
       if (response[0] == PACKET_EOF) {
         if (_state == STATE_FIELD_PACKETS) {

--- a/test/integration_test.dart
+++ b/test/integration_test.dart
@@ -46,11 +46,11 @@ void main(List<String> args) {
 
   var options = new OptionsFile('connection.options');
   var user = options.getString('user');
-  var password = options.getString('password');
+  var password = options.getString('password', null);
   var port = options.getInt('port', 3306);
   var db = options.getString('db');
   var host = options.getString('host', 'localhost');
-  
+
   runIntTests(user, password, db, port, host);
   runIntTests2(user, password, db, port, host);
   runCharsetTests(user, password, db, port, host);


### PR DESCRIPTION
We are considering that if the first byte in the response equals to '00',
this is an indicator of 'okPacket', but it appears MySQL also sends '00'
if the first column in the record is a blank string.

To fix that, I added an additional check that we are not in the state
when we are expecting row results, when we considering that an
'okPacket'.

It's a possible fix for #56. What do you think?