### PR TITLE
Updated to work with Dart 1.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog
 v0.15.0
 -------
 * Updated dependency to allow more recent versions of crypto and mockito.
-* Removed use of deprecated SHA1 class in auth_handler.dart.
+* Removed deprecated SHA1 class in auth_handler.dart: for crypto >=1.0.0.
 * Fixed code warnings.
 
 v0.14.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog
 v0.15.0
 -------
 * Updated dependency to allow more recent versions of crypto and mockito.
+* Removed use of deprecated SHA1 class in auth_handler.dart.
 
 v0.14.1
 -------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+v0.15.0
+-------
+* Updated dependency to allow more recent versions of crypto and mockito.
+
 v0.14.1
 -------
 * Fix the changelog formatting, so you can actually see what changed in v0.14.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-v0.15.0
+v0.14.2
 -------
 * Updated dependency to allow more recent versions of crypto and mockito.
 * Removed deprecated SHA1 class in auth_handler.dart: for crypto >=1.0.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ v0.15.0
 -------
 * Updated dependency to allow more recent versions of crypto and mockito.
 * Removed use of deprecated SHA1 class in auth_handler.dart.
+* Fixed code warnings.
 
 v0.14.1
 -------

--- a/README.md
+++ b/README.md
@@ -95,6 +95,26 @@ Development
 To run the examples and tests, you'll need to create a 'connection.options' file by
 copying 'connection.options.example' and modifying the settings.
 
+Note: some of the tests will modify the database specified in the
+connection options file.  For example, creating tables in it.
+
+From the command line, [run the tests using
+pub](https://pub.dartlang.org/packages/test#running-tests). They can
+be run individually:
+
+```sh
+$ pub run test test/unit_test.dart
+$ pub run test test/interleave_test.dart
+$ pub run test test/integration_test.dart
+```
+
+It should be possible to run all the tests, but this currently does
+not work due to how the unit tests have been written.
+
+```sh
+$ pub run test  # this does not work yet
+```
+
 Licence
 -------
 

--- a/lib/sqljocky.dart
+++ b/lib/sqljocky.dart
@@ -8,6 +8,8 @@ import 'dart:io';
 import 'dart:math' as math;
 
 import 'package:crypto/crypto.dart';
+import 'package:crypto/src/digest_sink.dart';
+
 import 'package:logging/logging.dart';
 
 import 'constants.dart';

--- a/lib/src/auth/auth_handler.dart
+++ b/lib/src/auth/auth_handler.dart
@@ -22,18 +22,16 @@ class _AuthHandler extends _Handler {
     if (_password == null) {
       hash = <int>[];
     } else {
-      var hasher = new SHA1();
-      hasher.add(UTF8.encode(_password));
-      var hashedPassword = hasher.close();
+      var hashedPassword = sha1.convert(UTF8.encode(_password)).bytes;
 
-      hasher = new SHA1();
-      hasher.add(hashedPassword);
-      var doubleHashedPassword = hasher.close();
+      var doubleHashedPassword = sha1.convert(hashedPassword).bytes;
 
-      hasher = new SHA1();
-      hasher.add(_scrambleBuffer);
-      hasher.add(doubleHashedPassword);
-      var hashedSaltedPassword = hasher.close();
+      var sink = new DigestSink();
+      var s = sha1.startChunkedConversion(sink);
+      s.add(_scrambleBuffer);
+      s.add(doubleHashedPassword);
+      s.close();
+      var hashedSaltedPassword = sink.value.bytes;
 
       hash = new List<int>(hashedSaltedPassword.length);
       for (var i = 0; i < hash.length; i++) {

--- a/lib/src/auth/handshake_handler.dart
+++ b/lib/src/auth/handshake_handler.dart
@@ -52,14 +52,14 @@ class _HandshakeHandler extends _Handler {
       serverStatus = response.readUint16();
       serverCapabilities += (response.readUint16() << 0x10);
 
-      var secure = serverCapabilities & CLIENT_SECURE_CONNECTION;
-      var plugin = serverCapabilities & CLIENT_PLUGIN_AUTH;
+      // var secure = serverCapabilities & CLIENT_SECURE_CONNECTION;
+      // var plugin = serverCapabilities & CLIENT_PLUGIN_AUTH;
 
       scrambleLength = response.readByte();
       response.skip(10);
       if (serverCapabilities & CLIENT_SECURE_CONNECTION > 0) {
         var scrambleBuffer2 = response.readList(math.max(13, scrambleLength - 8) - 1);
-        var nullTerminator = response.readByte();
+        var _ = response.readByte(); // nullTerminator: value ignored
         scrambleBuffer = new List<int>(scrambleBuffer1.length + scrambleBuffer2.length);
         scrambleBuffer.setRange(0, 8, scrambleBuffer1);
         scrambleBuffer.setRange(8, 8 + scrambleBuffer2.length, scrambleBuffer2);

--- a/lib/src/buffer.dart
+++ b/lib/src/buffer.dart
@@ -198,6 +198,9 @@ class Buffer {
         return readUint24();
       case 254:
         return readUint64();
+      default:
+        // MySQL specification does not define 255
+        throw new RangeError('length coded binary: unexpected value 255');
     }
   }
 
@@ -214,6 +217,7 @@ class Buffer {
     if (value < (2 << 63)) {
       return 5;
     }
+    throw new RangeError('measureLengthCodedBinary: unexpected value');
   }
 
   /**

--- a/lib/src/buffered_socket.dart
+++ b/lib/src/buffered_socket.dart
@@ -75,6 +75,8 @@ class BufferedSocket {
       return bufferedSocket;
     } catch (e) {
       onError(e);
+      assert(false); // should never get here: onError should throw exception
+      return null; // to shut up warnings
     }
   }
 

--- a/lib/src/connection.dart
+++ b/lib/src/connection.dart
@@ -261,7 +261,7 @@ class _Connection {
       _compressedHeaderBuffer.writeUint24(encodedHeader.length + encodedBuffer.length);
       _compressedHeaderBuffer.writeByte(++_compressedPacketNumber);
       _compressedHeaderBuffer.writeUint24(4 + buffer.length);
-      _socket.writeBuffer(_compressedHeaderBuffer);
+      return _socket.writeBuffer(_compressedHeaderBuffer);
     } else {
       log.fine("sendBuffer header");
       return _sendBufferPart(buffer, 0);

--- a/lib/src/connection_pool.dart
+++ b/lib/src/connection_pool.dart
@@ -206,6 +206,8 @@ class ConnectionPool extends Object with _ConnectionHelpers implements Queriable
       return results;
     } catch (e) {
       _releaseReuseThrow(cnx, e);
+      assert(false); // should not get here: _releaseReuseThrow throws exception
+      return null; // to shut up warnings
     }
   }
 
@@ -313,6 +315,8 @@ class ConnectionPool extends Object with _ConnectionHelpers implements Queriable
       return new _TransactionImpl._(cnx, this);
     } catch (e) {
       _releaseReuseThrow(cnx, e);
+      assert(false); // should not get to here: _releaseReuseThrow should throw
+      return null; // to shut up warnings
     }
   }
 

--- a/lib/src/handlers/parameter_packet.dart
+++ b/lib/src/handlers/parameter_packet.dart
@@ -1,6 +1,7 @@
 part of sqljocky;
 
 // not using this one yet
+/*
 class _ParameterPacket {
   int _type;
   int _flags;
@@ -19,3 +20,4 @@ class _ParameterPacket {
     _length = buffer.readUint32();
   }
 }
+*/

--- a/lib/src/handlers/quit_handler.dart
+++ b/lib/src/handlers/quit_handler.dart
@@ -1,5 +1,6 @@
 part of sqljocky;
 
+/*
 class _QuitHandler extends _Handler {
   _QuitHandler() {
     log = new Logger("QuitHandler");
@@ -15,3 +16,4 @@ class _QuitHandler extends _Handler {
     throw new MySqlProtocolError._("Shouldn't have received a response after sending a QUIT message");
   }
 }
+*/

--- a/lib/src/query.dart
+++ b/lib/src/query.dart
@@ -109,6 +109,8 @@ class Query extends Object with _ConnectionHelpers {
       return results;
     } catch (e) {
       _releaseReuseThrow(preparedQuery.cnx, e);
+      assert(false); // should not get to here: _releaseReuseThrow always throws
+      return null; // to shut up warnings
     }
   }
 

--- a/lib/src/retained_connection.dart
+++ b/lib/src/retained_connection.dart
@@ -54,7 +54,7 @@ abstract class RetainedConnection extends QueriableConnection {
 class _RetainedConnectionImpl extends _RetainedConnectionBase implements RetainedConnection {
   _RetainedConnectionImpl._(cnx, pool) : super._(cnx, pool);
 
-  Future release() {
+  Future release() async {
     _checkReleased();
     _released = true;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sqljocky
-version: 0.14.1
+version: 0.15.0
 author: James Ots <code@jamesots.com>
 description: A MySQL connector
 homepage: https://github.com/jamesots/sqljocky
@@ -7,10 +7,10 @@ environment:
   sdk: '>=1.11.0 <2.0.0'
 documentation: http://jamesots.github.io/sqljocky/docs
 dependencies:
-  crypto: '>=0.9.0 <0.10.0'
+  crypto: '>=0.9.0 <3.0.0'
   logging: '>=0.11.1 <0.12.0'
   options_file: '>=0.11.0 <0.12.0'
 dev_dependencies:
   test: '>=0.12.3+9 <0.13.0'
-  mockito: '>=0.10.1 <0.11.0'
+  mockito: '>=0.10.1 <3.0.0'
   args: any

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sqljocky
-version: 0.15.0
+version: 0.14.2
 author: James Ots <code@jamesots.com>
 description: A MySQL connector
 homepage: https://github.com/jamesots/sqljocky

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: '>=1.11.0 <2.0.0'
 documentation: http://jamesots.github.io/sqljocky/docs
 dependencies:
-  crypto: '>=0.9.0 <3.0.0'
+  crypto: '>=0.9.2 <3.0.0'
   logging: '>=0.11.1 <0.12.0'
   options_file: '>=0.11.0 <0.12.0'
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,4 +13,3 @@ dependencies:
 dev_dependencies:
   test: '>=0.12.3+9 <0.13.0'
   mockito: '>=0.10.1 <3.0.0'
-  args: any

--- a/test/integration/errors.dart
+++ b/test/integration/errors.dart
@@ -14,7 +14,7 @@ void runErrorTests(String user, String password, String db, int port, String hos
 //          useCompression: false,
           useSSL: true);
       var cnx = await pool.getConnection();
-      print("Connection secure: ${cnx.usingSSL}");
+      // print("Connection secure: ${cnx.usingSSL}");
       cnx.release();
       return setup(pool, "stream", "create table stream (id integer, name text)");
     });

--- a/test/integration/execute_multi.dart
+++ b/test/integration/execute_multi.dart
@@ -1,15 +1,28 @@
 part of integrationtests;
 
-void runExecuteMultiTests(String user, String password, String db, int port, String host) {
+void runExecuteMultiTests(
+    String user, String password, String db, int port, String host) {
   ConnectionPool pool;
-  group('executeMulti tests:', () {
-    test('setup', () {
-      pool = new ConnectionPool(user: user, password: password, db: db, port: port, host: host, max: 2);
-      return setup(pool, "stream", "create table stream (id integer, name text)",
+  group('executeMulti', () {
+    setUp(() async {
+      pool = new ConnectionPool(
+          user: user,
+          password: password,
+          db: db,
+          port: port,
+          host: host,
+          max: 2);
+      expect(pool, isNotNull);
+      var result = await setup(
+          pool,
+          "stream",
+          "create table stream (id integer, name text)",
           "insert into stream (id, name) values (1, 'A'), (2, 'B'), (3, 'C')");
+      expect(result.affectedRows, equals(3),
+          reason: 'incorrect number of rows affected');
     });
 
-    test('store data', () async {
+    test('select', () async {
       var query = await pool.prepare('select * from stream where id = ?');
       var values = await query.executeMulti([
         [1],
@@ -38,11 +51,22 @@ void runExecuteMultiTests(String user, String password, String db, int port, Str
 
       await result.first;
 
+      // TODO: library code or test needs fixing
+      //
+      // The following sometimes tries to call 'processResponse' on null
+      // in lib/src/results/connection.dart line 190.
+      //
+      // Or sometimes produces this error: "MySQL Client Error:
+      // Connection #1 cannot process a request for Instance of
+      // '_QueryStreamHandler' while a request is already in progress for
+      // Instance of '_ExecuteQueryHandler'"
+
       await query.close();
       await tran.rollback();
     });
 
-    test('close connection', () {
+    tearDown(() {
+      expect(pool, isNotNull);
       pool.closeConnectionsWhenNotInUse();
     });
   });

--- a/test/integration/one.dart
+++ b/test/integration/one.dart
@@ -1,6 +1,8 @@
 part of integrationtests;
 
 void runIntTests(String user, String password, String db, int port, String host) {
+  var log = new Logger("integration.runIntTests");
+
   ConnectionPool pool;
   group('some tests:', () {
     test('create pool', () {
@@ -32,9 +34,9 @@ void runIntTests(String user, String password, String db, int port, String host)
     test('show tables', () async {
       var c = new Completer();
       var results = await pool.query("show tables");
-      print("tables");
+      log.fine("tables");
       results.listen((row) {
-        print("table: $row");
+        log.fine("table: $row");
       }, onDone: () {
         c.complete();
       });
@@ -43,8 +45,8 @@ void runIntTests(String user, String password, String db, int port, String host)
 
     test('describe stuff', () async {
       var results = await pool.query("describe test1");
-      print("table test1");
-      await showResults(results);
+      log.fine("table test1");
+      await showResults(results, log);
     });
 
     test('small blobs', () async {
@@ -82,7 +84,7 @@ void runIntTests(String user, String password, String db, int port, String host)
     });
 
     test('insert stuff', () async {
-      print("insert stuff test");
+      log.fine("insert stuff test");
       var query = await pool.prepare("insert into test1 (atinyint, asmallint, amediumint, abigint, aint, "
           "adecimal, afloat, adouble, areal, "
           "aboolean, abit, aserial, "
@@ -136,10 +138,10 @@ void runIntTests(String user, String password, String db, int port, String host)
       values.add("a");
       values.add("a,b");
 
-      print("executing");
+      log.fine("executing");
       expect(1, equals(1)); // put some real expectations here
       var results = await query.execute(values);
-      print("updated ${results.affectedRows} ${results.insertId}");
+      log.fine("updated ${results.affectedRows} ${results.insertId}");
       expect(results.affectedRows, equals(1));
     });
 
@@ -178,19 +180,19 @@ void runIntTests(String user, String password, String db, int port, String host)
 
     test('data types (prepared)', () async {
       var results = await pool.prepareExecute('select * from test1', []);
-      print("----------- prepared results ---------------");
+      log.fine("----------- prepared results ---------------");
       preparedFields = results.fields;
       var list = await results.toList();
       values = list[0];
       for (var i = 0; i < results.fields.length; i++) {
         var field = results.fields[i];
-        print("${field.name} ${fieldTypeToString(field.type)} ${typeof(values[i])}");
+        log.fine("${field.name} ${fieldTypeToString(field.type)} ${typeof(values[i])}");
       }
     });
 
     test('data types (query)', () async {
       var results = await pool.query('select * from test1');
-      print("----------- query results ---------------");
+      log.fine("----------- query results ---------------");
       var list = await results.toList();
       var row = list[0];
       for (var i = 0; i < results.fields.length; i++) {
@@ -207,7 +209,7 @@ void runIntTests(String user, String password, String db, int port, String host)
         } else {
           expect(row[i], equals(values[i]));
         }
-        print("${field.name} ${fieldTypeToString(field.type)} ${typeof(row[i])}");
+        log.fine("${field.name} ${fieldTypeToString(field.type)} ${typeof(row[i])}");
       }
     });
 
@@ -221,7 +223,7 @@ void runIntTests(String user, String password, String db, int port, String host)
       }
       var resultList = await query.executeMulti(params);
       var end = new DateTime.now();
-      print(end.difference(start));
+      log.fine(end.difference(start));
       expect(resultList.length, equals(50));
       await trans.commit();
     });
@@ -264,15 +266,15 @@ void runIntTests(String user, String password, String db, int port, String host)
   });
 }
 
-Future showResults(Results results) {
+Future showResults(Results results, Logger log) {
   var c = new Completer();
   var fieldNames = <String>[];
   for (var field in results.fields) {
     fieldNames.add("${field.name}:${field.type}");
   }
-  print(fieldNames);
+  log.fine(fieldNames);
   results.listen((row) {
-    print(row);
+    log.fine(row);
   }, onDone: () {
     c.complete(null);
   });

--- a/test/integration/stored_procedures.dart
+++ b/test/integration/stored_procedures.dart
@@ -1,10 +1,17 @@
 part of integrationtests;
 
-void runStoredProcedureTests(String user, String password, String db, int port, String host) {
+void runStoredProcedureTests(
+    String user, String password, String db, int port, String host) {
   ConnectionPool pool;
   group('error tests:', () {
     test('setup', () {
-      pool = new ConnectionPool(user: user, password: password, db: db, port: port, host: host, max: 1);
+      pool = new ConnectionPool(
+          user: user,
+          password: password,
+          db: db,
+          port: port,
+          host: host,
+          max: 1);
 //      return setup(pool, "stream", "create table stream (id integer, name text)");
     });
 
@@ -16,6 +23,9 @@ void runStoredProcedureTests(String user, String password, String db, int port, 
 //END
 //''').then((results) {
 //        return query.query('call getall()');
+
+      var c = new Completer();
+
       var results = await pool.query('call getall()');
       results.listen((row) {}, onDone: () {
         c.complete();

--- a/test/integration/two.dart
+++ b/test/integration/two.dart
@@ -1,6 +1,8 @@
 part of integrationtests;
 
 void runIntTests2(String user, String password, String db, int port, String host) {
+  var log = new Logger("integration.runIntTests2");
+
   ConnectionPool pool;
   group('some tests:', () {
     test('create pool', () {
@@ -17,31 +19,31 @@ void runIntTests2(String user, String password, String db, int port, String host
       var finished = [];
       pool.ping().then((_) {
         finished.add(1);
-        print("ping 1 received");
+        log.fine("ping 1 received");
         c1.complete();
 
         pool.ping().then((_) {
           finished.add(4);
-          print("ping 4 received");
+          log.fine("ping 4 received");
           c4.complete();
         });
-        print("ping 4 sent");
+        log.fine("ping 4 sent");
       });
-      print("ping 1 sent");
+      log.fine("ping 1 sent");
 
       pool.ping().then((_) {
         finished.add(2);
-        print("ping 2 received");
+        log.fine("ping 2 received");
         c2.complete();
       });
-      print("ping 2 sent");
+      log.fine("ping 2 sent");
 
       pool.ping().then((_) {
         finished.add(3);
-        print("ping 3 received");
+        log.fine("ping 3 received");
         c3.complete();
       });
-      print("ping 3 sent");
+      log.fine("ping 3 sent");
 
       expect(finished, equals([]));
 

--- a/test/integration_test.dart
+++ b/test/integration_test.dart
@@ -2,7 +2,6 @@ library integrationtests;
 
 import 'dart:async';
 import 'dart:typed_data';
-//import 'package:args/args.dart';
 import 'package:logging/logging.dart';
 import 'package:options_file/options_file.dart';
 import 'package:sqljocky/constants.dart';
@@ -25,6 +24,8 @@ part 'integration/stored_procedures.dart';
 part 'integration/stream.dart';
 part 'integration/two.dart';
 
+var log = new Logger("integration"); // to show logging set log.level in main
+
 void main() {
   const configFilename = 'connection.options';
 
@@ -44,9 +45,7 @@ void main() {
   };
   Logger.root.onRecord.listen(listener);
 
-  //var parser = new ArgParser();
-  //parser.addOption('large_packets', allowed: ['true', 'false'], defaultsTo: 'true');
-  //var results = parser.parse(args);
+  // log.level = Level.ALL; // uncomment to print out details
 
   var host;
   var port;

--- a/test/integration_test.dart
+++ b/test/integration_test.dart
@@ -2,7 +2,7 @@ library integrationtests;
 
 import 'dart:async';
 import 'dart:typed_data';
-import 'package:args/args.dart';
+//import 'package:args/args.dart';
 import 'package:logging/logging.dart';
 import 'package:options_file/options_file.dart';
 import 'package:sqljocky/constants.dart';
@@ -25,7 +25,9 @@ part 'integration/stored_procedures.dart';
 part 'integration/stream.dart';
 part 'integration/two.dart';
 
-void main(List<String> args) {
+void main() {
+  const configFilename = 'connection.options';
+
   hierarchicalLoggingEnabled = true;
   Logger.root.level = Level.OFF;
 //  new Logger("ConnectionPool").level = Level.ALL;
@@ -42,16 +44,32 @@ void main(List<String> args) {
   };
   Logger.root.onRecord.listen(listener);
 
-  var parser = new ArgParser();
-  parser.addOption('large_packets', allowed: ['true', 'false'], defaultsTo: 'true');
-  var results = parser.parse(args);
+  //var parser = new ArgParser();
+  //parser.addOption('large_packets', allowed: ['true', 'false'], defaultsTo: 'true');
+  //var results = parser.parse(args);
 
-  var options = new OptionsFile('connection.options');
-  var user = options.getString('user');
-  var password = options.getString('password', null);
-  var port = options.getInt('port', 3306);
-  var db = options.getString('db');
-  var host = options.getString('host', 'localhost');
+  var host;
+  var port;
+  var db;
+  var user;
+  var password;
+
+  // Load database connection options from config file
+
+  var options = new OptionsFile(configFilename);
+  host = options.getString('host', 'localhost');
+  port = options.getInt('port', 3306);
+  db = options.getString('db');
+  user = options.getString('user');
+  password = options.getString('password');
+
+  test('config file is complete', () {
+    expect(db, isNotNull, reason: 'Config file missing "db": $configFilename');
+    expect(user, isNotNull,
+        reason: 'Config file missing "user": $configFilename');
+    expect(password, isNotNull,
+        reason: 'Config file missing "password": $configFilename');
+  });
 
   runPreparedQueryTests(user, password, db, port, host);
   runIntTests(user, password, db, port, host);

--- a/test/interleave_test.dart
+++ b/test/interleave_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:math';
+import 'dart:io';
 
 import 'package:logging/logging.dart';
 import 'package:options_file/options_file.dart';
@@ -144,6 +145,8 @@ class Example {
 }
 
 void main() {
+  const configFilename = 'connection.options';
+
   hierarchicalLoggingEnabled = true;
   Logger.root.level = Level.OFF;
 //  new Logger("ConnectionPool").level = Level.ALL;
@@ -156,14 +159,33 @@ void main() {
   var log = new Logger("Interleave");
   log.level = Level.ALL;
 
+  var host;
+  var port;
+  var db;
+  var user;
+  var password;
+
+  setUp(() {
+    // Load database connection options from config file
+    try {
+      var options = new OptionsFile(configFilename);
+      host = options.getString('host', 'localhost');
+      port = options.getInt('port', 3306);
+      db = options.getString('db');
+      user = options.getString('user');
+      password = options.getString('password');
+
+      expect(db, isNotNull, reason: '$configFilename: missing "db"');
+      expect(user, isNotNull, reason: '$configFilename: missing "user"');
+      expect(password, isNotNull, reason: '$configFilename: missing "password"');
+
+    } on FileSystemException catch(e) {
+      fail("Connection options file: $e");
+    }
+  });
+
   group('interleave', () {
     test('should complete interleaved operations', () async {
-      var options = new OptionsFile('connection.options');
-      var user = options.getString('user');
-      var password = options.getString('password');
-      var port = options.getInt('port', 3306);
-      var db = options.getString('db');
-      var host = options.getString('host', 'localhost');
 
       // create a connection
       log.fine("opening connection");

--- a/test/interleave_test.dart
+++ b/test/interleave_test.dart
@@ -14,6 +14,8 @@ import 'package:test/test.dart';
  * You must have a connection.options file in order for this to connect.
  */
 
+var log = new Logger("Interleave"); // to show logging set log.level in main
+
 class Example {
   var insertedIds = [];
   var rnd = new Random();
@@ -24,29 +26,29 @@ class Example {
   Future run() async {
     // drop the tables if they already exist
     await dropTables();
-    print("dropped tables");
+    log.finer("dropped tables");
     // then recreate the tables
     await createTables();
-    print("created tables");
+    log.finer("created tables");
     // add some data
     var futures = new List<Future>();
     for (var i = 0; i < 10; i++) {
       futures.add(addDataInTransaction());
       futures.add(readData());
     }
-    print("queued all operations");
+    log.finer("queued all operations");
     await Future.wait(futures);
-    print("data added and read");
+    log.finer("data added and read");
   }
 
   Future dropTables() {
-    print("dropping tables");
+    log.finer("dropping tables");
     var dropper = new TableDropper(pool, ['pets', 'people']);
     return dropper.dropTables();
   }
 
   Future createTables() {
-    print("creating tables");
+    log.finer("creating tables");
     var querier = new QueryRunner(pool, [
       'create table people (id integer not null auto_increment, '
           'name varchar(255), '
@@ -59,20 +61,22 @@ class Example {
           'primary key (id),'
           'foreign key (owner_id) references people (id))'
     ]);
-    print("executing queries");
+    log.finer("executing queries");
     return querier.executeQueries();
   }
 
   Future addData() async {
-    print("adding");
-    var query = await pool.prepare("insert into people (name, age) values (?, ?)");
+    log.finer("adding");
+    var query =
+        await pool.prepare("insert into people (name, age) values (?, ?)");
     var parameters = [
       ["Dave", 15],
       ["John", 16],
       ["Mavis", 93]
     ];
     await query.executeMulti(parameters);
-    query = await pool.prepare("insert into pets (name, species, owner_id) values (?, ?, ?)");
+    query = await pool
+        .prepare("insert into pets (name, species, owner_id) values (?, ?, ?)");
     parameters = [
       ["Rover", "Dog", 1],
       ["Daisy", "Cow", 2],
@@ -82,10 +86,11 @@ class Example {
   }
 
   Future addDataInTransaction() async {
-    print("adding");
+    log.finer("adding");
     var ids = [];
     var trans = await pool.startTransaction();
-    var query = await trans.prepare("insert into people (name, age) values (?, ?)");
+    var query =
+        await trans.prepare("insert into people (name, age) values (?, ?)");
     var parameters = [
       ["Dave", 15],
       ["John", 16],
@@ -95,8 +100,9 @@ class Example {
     for (var result in results) {
       ids.add(result.insertId);
     }
-    print("added people");
-    query = await trans.prepare("insert into pets (name, species, owner_id) values (?, ?, ?)");
+    log.finer("added people");
+    query = await trans
+        .prepare("insert into pets (name, species, owner_id) values (?, ?, ?)");
     var id1, id2, id3;
     if (insertedIds.length < 3) {
       id1 = ids[0];
@@ -112,32 +118,34 @@ class Example {
       ["Daisy", "Cow", id2],
       ["Spot", "Dog", id3]
     ];
-    print("adding pets");
+    log.finer("adding pets");
     try {
       results = await query.executeMulti(parameters);
-      print("added pets");
+      log.finer("added pets");
     } catch (e) {
-      print("Exception: $e");
+      log.finer("Exception: $e");
     }
-    print("committing");
+    log.finer("committing");
     await trans.commit();
-    print("committed");
+    log.finer("committed");
     insertedIds.addAll(ids);
   }
 
   Future readData() async {
-    print("querying");
-    var result = await pool.query('select p.id, p.name, p.age, t.name, t.species '
-        'from people p '
-        'left join pets t on t.owner_id = p.id');
-    print("got results");
+    log.finer("querying");
+    var result =
+        await pool.query('select p.id, p.name, p.age, t.name, t.species '
+            'from people p '
+            'left join pets t on t.owner_id = p.id');
+    log.finer("got results");
     var list = await result.toList();
     if (list != null) {
       for (var row in list) {
         if (row[3] == null) {
           print("ID: ${row[0]}, Name: ${row[1]}, Age: ${row[2]}, No Pets");
         } else {
-          print("ID: ${row[0]}, Name: ${row[1]}, Age: ${row[2]}, Pet Name: ${row[3]}, Pet Species ${row[4]}");
+          print(
+              "ID: ${row[0]}, Name: ${row[1]}, Age: ${row[2]}, Pet Name: ${row[3]}, Pet Species ${row[4]}");
         }
       }
     }
@@ -155,9 +163,7 @@ void main() {
   Logger.root.onRecord.listen((LogRecord r) {
     print("${r.time}: ${r.loggerName}: ${r.message}");
   });
-
-  var log = new Logger("Interleave");
-  log.level = Level.ALL;
+  // log.level = Level.ALL; // uncomment to print out details
 
   var host;
   var port;
@@ -177,19 +183,24 @@ void main() {
 
       expect(db, isNotNull, reason: '$configFilename: missing "db"');
       expect(user, isNotNull, reason: '$configFilename: missing "user"');
-      expect(password, isNotNull, reason: '$configFilename: missing "password"');
-
-    } on FileSystemException catch(e) {
+      expect(password, isNotNull,
+          reason: '$configFilename: missing "password"');
+    } on FileSystemException catch (e) {
       fail("Connection options file: $e");
     }
   });
 
   group('interleave', () {
     test('should complete interleaved operations', () async {
-
       // create a connection
       log.fine("opening connection");
-      var pool = new ConnectionPool(host: host, port: port, user: user, password: password, db: db, max: 5);
+      var pool = new ConnectionPool(
+          host: host,
+          port: port,
+          user: user,
+          password: password,
+          db: db,
+          max: 5);
       log.fine("connection open");
       // create an example class
       var example = new Example(pool);

--- a/test/unit/buffered_socket_test.dart
+++ b/test/unit/buffered_socket_test.dart
@@ -41,7 +41,10 @@ class MockSocket extends StreamView<RawSocketEvent> implements RawSocket {
 
   InternetAddress get address => null;
 
-  Future<RawSocket> close() {}
+  Future<RawSocket> close() async {
+    // pretend the socket is always, immediately, completely destroyed
+    return this;
+  }
 
   int get port => null;
 
@@ -53,11 +56,19 @@ class MockSocket extends StreamView<RawSocketEvent> implements RawSocket {
 
   int get remotePort => null;
 
-  bool setOption(SocketOption option, bool enabled) {}
+  bool setOption(SocketOption option, bool enabled) {
+    return true; // pretend option was set successfully
+  }
 
   void shutdown(SocketDirection direction) {}
 
-  int write(List<int> buffer, [int offset, int count]) {}
+  int write(List<int> buffer, [int offset, int count]) {
+    if (count != null) {
+      return count; // pretend requested number of bytes to write was written
+    } else {
+      return buffer.length; // pretend all of the buffer was written
+    }
+  }
 
   void set writeEventsEnabled(bool value) {
     if (value) {
@@ -181,7 +192,7 @@ void runBufferedSocketTests() {
       var onClosed = () {
         closed = true;
       };
-      var socket = await BufferedSocket.connect('localhost', 100,
+      var _ = await BufferedSocket.connect('localhost', 100,
           onDataReady: () {}, onDone: () {}, onError: (e) {}, onClosed: onClosed, socketFactory: factory);
       await rawSocket.closeRead();
       expect(closed, equals(true));

--- a/test/unit/field_by_name_test.dart
+++ b/test/unit/field_by_name_test.dart
@@ -51,7 +51,7 @@ void runFieldByNameTests() {
 
       Row row = new _StandardDataPacket._forTests(values, fieldIndex);
       try {
-        var x = row.one;
+        var _ = row.one;
         expect(true, isFalse);
       } on NoSuchMethodError {
         expect(true, isTrue);
@@ -109,7 +109,7 @@ void runFieldByNameTests() {
 
       Row row = new _BinaryDataPacket._forTests(values, fieldIndex);
       try {
-        var x = row.one;
+        var _ = row.one;
         expect(true, isFalse);
       } on NoSuchMethodError {
         expect(true, isTrue);

--- a/test/unit_test.dart
+++ b/test/unit_test.dart
@@ -8,6 +8,7 @@ import 'dart:math' as math;
 import 'dart:typed_data';
 
 import 'package:crypto/crypto.dart';
+import 'package:crypto/src/digest_sink.dart';
 import 'package:logging/logging.dart';
 import 'package:mockito/mockito.dart';
 import 'package:sqljocky/constants.dart';


### PR DESCRIPTION
### Updated crypto dependency

Updated dependency on the _crypto_ package to '>=0.9.2 <3.0.0' to allow a newer version of _crypto_ to be used that is compatible with Dart 1.24.

This was necessary, since the previous _crypto_ dependency was '>=0.9.0 <0.10.0' which used _crypto_ 0.9.2+1 -- and that version of _crypto_ is incompatible with Dart 1.24 and newer. The underlying problem is because _crypto_ 0.9.2+1 only works with _convert_ 1.1.1 and earlier, and _convert_ 1.1.1 and earlier needed the _ChunkedConverter_ class. But Dart 1.24 has removed the _ChunkedConverter_ class. Unfortunately, this was a [breaking change](https://github.com/dart-lang/sdk/blob/master/CHANGELOG.md) even though the major version number of Dart was not changed to indicate that.

The result is _sqljocky_ 0.14.1 is incompatible with Dart 1.24 and newer. The error message seen when trying to run "pub get" is:

```
Failed to precompile test:test:
'package:convert/src/hex/encoder.dart': malformed type: line 20 pos 13: cannot resolve
  class 'ChunkedConverter' from 'HexEncoder'
    extends ChunkedConverter<List<int>, String, List<int>, String> {
```

The newer versions of _crypto_ uses newer versions of _convert_ which are compatible with Dart 1.24, because they do not need the _ChunkedConverter_ class.

Some code changes were necessary in _auth_handler.dart_ to work with the newer versions of _crypto. Previously it was using a deprecated class (SHA1) that has been removed since _crypto_ 1.0.0.

### Cleaned up warnings

Cleaned up the code to remove some warnings (e.g. unused variables).

### Cleaned up tests

Also, changed the _print_ statements in the tests to go to logging (which is disabled by default). This way they don't clutter up the output so the `pub run test` command can parse the output.

**Only one problem:** integration test "issue 43" does not pass. But it didn't seem to pass before these changes. So was it previously broken?

